### PR TITLE
Support Schema Registry to work with DB schema which is not the public schema

### DIFF
--- a/src/build-server.ts
+++ b/src/build-server.ts
@@ -8,6 +8,7 @@ import { ErrorResponse } from './core/types'
 export interface buildOptions {
   logger?: boolean
   databaseConnectionUrl: string
+  databaseSchema?: string
   basicAuth?: string
   prettyPrint?: boolean
   jwtSecret?: string
@@ -28,6 +29,7 @@ export default function build(opts: buildOptions) {
   // Database client
   fastify.register(knexPlugin, {
     databaseConnectionUrl: opts.databaseConnectionUrl,
+    databaseSchema: opts.databaseSchema,
   })
 
   // Registry

--- a/src/core/env.schema.ts
+++ b/src/core/env.schema.ts
@@ -2,6 +2,7 @@ import S from 'fluent-json-schema'
 
 export default S.object()
   .prop('DATABASE_URL', S.string())
+  .prop('DATABASE_SCHEMA', S.string().default('public'))
   .prop('BASIC_AUTH', S.string())
   .prop('JWT_SECRET', S.string())
   .prop('PRETTY_PRINT', S.boolean().default(false))
@@ -9,6 +10,7 @@ export default S.object()
 
 export interface AppSchema {
   DATABASE_URL: string
+  DATABASE_SCHEMA: string
   PRETTY_PRINT: boolean
   LOGGER: boolean
   BASIC_AUTH: string

--- a/src/core/knex-plugin.ts
+++ b/src/core/knex-plugin.ts
@@ -10,6 +10,7 @@ declare module 'fastify' {
 
 export interface KnexPluginOptions {
   databaseConnectionUrl: string
+  databaseSchema?: string
 }
 
 export default fp<KnexPluginOptions>(async function (fastify, opts) {
@@ -22,6 +23,7 @@ export default fp<KnexPluginOptions>(async function (fastify, opts) {
       debug: fastify.log.debug,
     },
     connection: opts.databaseConnectionUrl,
+    searchPath: opts.databaseSchema,
   })
 
   fastify.decorate('knexHealthcheck', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ const config = envSchema({
 
 const app = build({
   databaseConnectionUrl: config.DATABASE_URL,
+  databaseSchema: config.DATABASE_SCHEMA,
   basicAuth: config.BASIC_AUTH,
   jwtSecret: config.JWT_SECRET,
   logger: config.LOGGER,

--- a/src/knexfile.ts
+++ b/src/knexfile.ts
@@ -7,6 +7,7 @@ dotenv.config({ path: join(__dirname, '..', '.env') })
 export default {
   client: 'pg',
   connection: process.env.DATABASE_URL,
+  searchPath: [process.env.DATABASE_SCHEMA || 'public'],
   migrations: {
     extension: 'ts',
     directory: join(__dirname, '/migrations'),


### PR DESCRIPTION
As an Organization, I want to be able to start up the schema registry on DB schema which isn't the public schema.

-- Added environment variables DATABASE_SCHEMA